### PR TITLE
feat: include overflow stats in stats event

### DIFF
--- a/client/schema.go
+++ b/client/schema.go
@@ -22,13 +22,13 @@ const (
 
 // Event schema versions, only increment when the schema changes
 const (
-	activeEventVersion        int = 0
-	unbondingEventVersion     int = 0
-	withdrawEventVersion      int = 0
-	expiredEventVersion       int = 0
-	statsEventVersion         int = 0
-	btcInfoEventVersion       int = 0
-	confirmedInfoEventVersion int = 0
+	ActiveEventVersion        int = 0
+	UnbondingEventVersion     int = 0
+	WithdrawEventVersion      int = 0
+	ExpiredEventVersion       int = 0
+	StatsEventVersion         int = 1
+	BtcInfoEventVersion       int = 0
+	ConfirmedInfoEventVersion int = 0
 )
 
 type EventType int
@@ -74,7 +74,7 @@ func NewActiveStakingEvent(
 	isOverflow bool,
 ) ActiveStakingEvent {
 	return ActiveStakingEvent{
-		SchemaVersion:         activeEventVersion,
+		SchemaVersion:         ActiveEventVersion,
 		EventType:             ActiveStakingEventType,
 		StakingTxHashHex:      stakingTxHashHex,
 		StakerPkHex:           stakerPkHex,
@@ -119,7 +119,7 @@ func NewUnbondingStakingEvent(
 	unbondingTxHashHex string,
 ) UnbondingStakingEvent {
 	return UnbondingStakingEvent{
-		SchemaVersion:           unbondingEventVersion,
+		SchemaVersion:           UnbondingEventVersion,
 		EventType:               UnbondingStakingEventType,
 		StakingTxHashHex:        stakingTxHashHex,
 		UnbondingStartHeight:    unbondingStartHeight,
@@ -147,7 +147,7 @@ func (e WithdrawStakingEvent) GetStakingTxHashHex() string {
 
 func NewWithdrawStakingEvent(stakingTxHashHex string) WithdrawStakingEvent {
 	return WithdrawStakingEvent{
-		SchemaVersion:    withdrawEventVersion,
+		SchemaVersion:    WithdrawEventVersion,
 		EventType:        WithdrawStakingEventType,
 		StakingTxHashHex: stakingTxHashHex,
 	}
@@ -170,7 +170,7 @@ func (e ExpiredStakingEvent) GetStakingTxHashHex() string {
 
 func NewExpiredStakingEvent(stakingTxHashHex string, txType string) ExpiredStakingEvent {
 	return ExpiredStakingEvent{
-		SchemaVersion:    expiredEventVersion,
+		SchemaVersion:    ExpiredEventVersion,
 		EventType:        ExpiredStakingEventType,
 		StakingTxHashHex: stakingTxHashHex,
 		TxType:           txType,
@@ -185,6 +185,7 @@ type StatsEvent struct {
 	FinalityProviderPkHex string    `json:"finality_provider_pk_hex"`
 	StakingValue          uint64    `json:"staking_value"`
 	State                 string    `json:"state"`
+	IsOverflow            bool      `json:"is_overflow"`
 }
 
 func (e StatsEvent) GetEventType() EventType {
@@ -201,15 +202,17 @@ func NewStatsEvent(
 	finalityProviderPkHex string,
 	stakingValue uint64,
 	state string,
+	isOverflow bool,
 ) StatsEvent {
 	return StatsEvent{
-		SchemaVersion:         statsEventVersion,
+		SchemaVersion:         StatsEventVersion,
 		EventType:             StatsEventType,
 		StakingTxHashHex:      stakingTxHashHex,
 		StakerPkHex:           stakerPkHex,
 		FinalityProviderPkHex: finalityProviderPkHex,
 		StakingValue:          stakingValue,
 		State:                 state,
+		IsOverflow:            isOverflow,
 	}
 }
 
@@ -232,7 +235,7 @@ func (e BtcInfoEvent) GetStakingTxHashHex() string {
 
 func NewBtcInfoEvent(height, confirmedTvl, unconfirmedTvl uint64) BtcInfoEvent {
 	return BtcInfoEvent{
-		SchemaVersion:  btcInfoEventVersion,
+		SchemaVersion:  BtcInfoEventVersion,
 		EventType:      BtcInfoEventType,
 		Height:         height,
 		ConfirmedTvl:   confirmedTvl,
@@ -258,7 +261,7 @@ func (e ConfirmedInfoEvent) GetStakingTxHashHex() string {
 
 func NewConfirmedInfoEvent(height, tvl uint64) ConfirmedInfoEvent {
 	return ConfirmedInfoEvent{
-		SchemaVersion: confirmedInfoEventVersion,
+		SchemaVersion: ConfirmedInfoEventVersion,
 		EventType:     ConfirmedInfoEventType,
 		Height:        height,
 		Tvl:           tvl,

--- a/queuemngr/queue_manager.go
+++ b/queuemngr/queue_manager.go
@@ -77,14 +77,14 @@ func (qc *QueueManager) Start() error {
 	return nil
 }
 
-func PushEvent[T any](qc *QueueManager, ev T) error {
+func PushEvent[T any](queueClient client.QueueClient, ev T) error {
 	jsonBytes, err := json.Marshal(ev)
 	if err != nil {
 		return err
 	}
 	messageBody := string(jsonBytes)
 
-	err = qc.StakingQueue.SendMessage(context.TODO(), messageBody)
+	err = queueClient.SendMessage(context.TODO(), messageBody)
 	if err != nil {
 		return fmt.Errorf("failed to push event: %w", err)
 	}

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -149,6 +149,23 @@ func buildNExpiryEvents(numOfEvent int) []*client.ExpiredStakingEvent {
 	return expiryEvents
 }
 
+func buildNStatsEvents(stakerHash string, numOfEvent int) []*client.StatsEvent {
+	var statsEvents []*client.StatsEvent
+	for i := 0; i < numOfEvent; i++ {
+		activeStakingEvent := client.NewStatsEvent(
+			"0x1234567890abcdef"+fmt.Sprint(i),
+			stakerHash,
+			"0xabcdef1234567890"+fmt.Sprint(i),
+			1+uint64(i),
+			"active",
+			false,
+		)
+
+		statsEvents = append(statsEvents, &activeStakingEvent)
+	}
+	return statsEvents
+}
+
 func buildNBtcInfoEvents(numOfEvent int) []*client.BtcInfoEvent {
 	var btcInfoEvents []*client.BtcInfoEvent
 	for i := 0; i < numOfEvent; i++ {


### PR DESCRIPTION
The name "statsEvenet" is probably a big mistake. What it really mean is a type of event that is secondary to the staking events.

I'm adding the overflow property into the stats event so that we can decouple stats from the staking events as the API endpoint around stats fetching is getting more and more complex.
I would like to avoid touching any staking data flow when deal with secondary information(i.e information as a result of the stats event)