### PR TITLE
chore: change v2 queue names 

### DIFF
--- a/client/schema.go
+++ b/client/schema.go
@@ -1,8 +1,8 @@
 package client
 
 const (
-	ActiveStakingQueueName    string = "active_staking_queue"
-	UnbondingStakingQueueName string = "unbonding_staking_queue"
+	ActiveStakingQueueName    string = "v2_active_staking_queue"
+	UnbondingStakingQueueName string = "v2_unbonding_staking_queue"
 )
 
 const (


### PR DESCRIPTION
Fixes - https://github.com/babylonlabs-io/babylon-staking-indexer/issues/86

Add v2_ prefix to the queues to avoid clashing with v1.